### PR TITLE
feat: 認証画面のデザイン刷新、名前項目の追加、およびパスワード可視化機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,21 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    # 新規登録（sign_up）の際に name を許可
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
+    # プロフィール更新（account_update）の際に name を許可
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
+  end
+
+  private
+
+  # ログアウト後にログイン画面へ飛ばす
+  def after_sign_out_path_for(resource_or_scope)
+    new_user_session_path
+  end
 end

--- a/app/javascript/controllers/password_visibility_controller.js
+++ b/app/javascript/controllers/password_visibility_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "input", "icon" ]
+
+  toggle() {
+    const type = this.inputTarget.type === "password" ? "text" : "password"
+    this.inputTarget.type = type
+
+    // アイコンの見た目を切り替える（Bootstrap Iconsを使用）
+    this.iconTarget.classList.toggle("bi-eye")
+    this.iconTarget.classList.toggle("bi-eye-slash")
+  }
+}

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <p><%= f.label :email %></p>
+    <p><%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %></p>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <p><%= f.label :password, "New password" %></p>
+    <% if @minimum_password_length %>
+      <p><em>(<%= @minimum_password_length %> characters minimum)</em></p>
+    <% end %>
+    <p><%= f.password_field :password, autofocus: true, autocomplete: "new-password" %></p>
+  </div>
+
+  <div class="field">
+    <p><%= f.label :password_confirmation, "Confirm new password" %></p>
+    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <p><%= f.label :email %></p>
+    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me password reset instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,88 @@
+<div class="max-w-md mx-auto mt-10 px-6 py-8 bg-white shadow-xl rounded-2xl border border-base-border">
+  <h2 class="text-2xl font-bold text-center text-primary mb-8">プロフィール編集</h2>
+
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+
+    <%# お名前（Name） %>
+    <div class="mb-5">
+      <%= f.label :name, "お名前", class: "block text-sm font-bold text-base-text mb-2" %>
+      <%= f.text_field :name, autofocus: true, placeholder: "ログイン時に表示されます", 
+          class: "w-full px-4 py-3 rounded-xl border border-base-border focus:ring-2 focus:ring-accent focus:border-transparent outline-none transition-all bg-base-bg" %>
+    </div>
+
+    <%# メールアドレス（編集不可・グレーアウト） %>
+    <div class="mb-5">
+      <%= f.label :email, "メールアドレス", class: "block text-sm font-bold text-gray-400 mb-2" %>
+      <%= f.email_field :email, 
+          readonly: true, 
+          class: "w-full px-4 py-3 rounded-xl border border-base-border bg-gray-100 text-gray-500 cursor-not-allowed outline-none" %>
+      <p class="text-[10px] text-gray-400 mt-1">※メールアドレスの変更は現在対応しておりません</p>
+    </div>
+
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <div class="mb-5 text-sm text-amber-600 italic">
+        現在、次のアドレスの確認待ちです: <%= resource.unconfirmed_email %>
+      </div>
+    <% end %>
+
+    <hr class="my-8 border-base-border">
+
+    <%# 新しいパスワード %>
+    <div class="mb-5" data-controller="password-visibility">
+      <%= f.label :password, "新しいパスワード", class: "block text-sm font-bold text-base-text mb-1" %>
+      <span class="text-xs text-gray-500 mb-2 block">※変更しない場合は空欄のままにしてください</span>
+      <div class="relative flex items-center">
+        <%= f.password_field :password, autocomplete: "new-password", 
+            data: { password_visibility_target: "input" },
+            class: "w-full px-4 py-3 rounded-xl border border-base-border focus:ring-2 focus:ring-accent focus:border-transparent outline-none transition-all bg-base-bg pr-12" %>
+        <button type="button" data-action="password-visibility#toggle" class="absolute right-4 text-gray-400 focus:outline-none hover:text-primary cursor-pointer">
+          <i class="bi bi-eye-slash text-xl" data-password-visibility-target="icon"></i>
+        </button>
+      </div>
+    </div>
+
+    <%# パスワード（確認用） %>
+    <div class="mb-5" data-controller="password-visibility">
+      <%= f.label :password_confirmation, "新しいパスワード（確認用）", class: "block text-sm font-bold text-base-text mb-2" %>
+      <div class="relative flex items-center">
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", 
+            data: { password_visibility_target: "input" },
+            class: "w-full px-4 py-3 rounded-xl border border-base-border focus:ring-2 focus:ring-accent focus:border-transparent outline-none transition-all bg-base-bg pr-12" %>
+        <button type="button" data-action="password-visibility#toggle" class="absolute right-4 text-gray-400 focus:outline-none hover:text-primary cursor-pointer">
+          <i class="bi bi-eye-slash text-xl" data-password-visibility-target="icon"></i>
+        </button>
+      </div>
+    </div>
+
+    <hr class="my-8 border-base-border">
+
+    <%# 現在のパスワード（更新に必須） %>
+    <div class="mb-8 p-4 bg-rose-50 rounded-xl border border-rose-100" data-controller="password-visibility">
+      <%= f.label :current_password, "現在のパスワード", class: "block text-sm font-bold text-rose-800 mb-2" %>
+      <div class="relative flex items-center">
+        <%= f.password_field :current_password, autocomplete: "current-password", 
+            data: { password_visibility_target: "input" },
+            class: "w-full px-4 py-3 rounded-xl border border-rose-200 focus:ring-2 focus:ring-rose-500 focus:border-transparent outline-none transition-all bg-white pr-12" %>
+        <button type="button" data-action="password-visibility#toggle" class="absolute right-4 text-rose-400 focus:outline-none hover:text-rose-600 cursor-pointer">
+          <i class="bi bi-eye-slash text-xl" data-password-visibility-target="icon"></i>
+        </button>
+      </div>
+    </div>
+
+    <div class="mb-6">
+      <%= f.submit "変更を保存する", class: "w-full py-4 bg-primary text-white font-bold rounded-xl shadow-lg hover:opacity-90 transition-opacity cursor-pointer" %>
+    </div>
+  <% end %>
+
+  <div class="mt-10 pt-8 border-t border-base-border text-center">
+    <%= button_to "アカウントを削除する", registration_path(resource_name), 
+        data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" }, 
+        method: :delete, 
+        class: "text-sm text-rose-500 hover:underline font-medium" %>
+  </div>
+
+  <div class="mt-4 text-center">
+    <%= link_to "戻る", :back, class: "text-sm text-gray-500 hover:text-primary" %>
+  </div>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,56 @@
+<div class="max-w-md mx-auto mt-10 px-6 py-8 bg-white shadow-xl rounded-2xl border border-base-border">
+  <h2 class="text-2xl font-bold text-center text-primary mb-8">アカウント登録</h2>
+
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+
+    <%# お名前（Name） %>
+    <div class="mb-5">
+      <%= f.label :name, "お名前", class: "block text-sm font-bold text-base-text mb-2" %>
+      <%= f.text_field :name, autofocus: true, placeholder: "ログイン時に表示されます", 
+          class: "w-full px-4 py-3 rounded-xl border border-base-border focus:ring-2 focus:ring-accent focus:border-transparent outline-none transition-all bg-base-bg" %>
+    </div>
+
+    <%# メールアドレス %>
+    <div class="mb-5">
+      <%= f.label :email, "メールアドレス", class: "block text-sm font-bold text-base-text mb-2" %>
+      <%= f.email_field :email, autocomplete: "email",  placeholder: "example@pakelog.com",
+          class: "w-full px-4 py-3 rounded-xl border border-base-border focus:ring-2 focus:ring-accent focus:border-transparent outline-none transition-all bg-base-bg" %>
+    </div>
+
+    <%# パスワード（修正箇所1） %>
+    <div class="mb-5" data-controller="password-visibility">
+      <%= f.label :password, "パスワード（6文字以上）", class: "block text-sm font-bold text-base-text mb-2" %>
+      <div class="relative flex items-center">
+        <%= f.password_field :password, autocomplete: "new-password", 
+            data: { password_visibility_target: "input" },
+            class: "w-full px-4 py-3 rounded-xl border border-base-border focus:ring-2 focus:ring-accent focus:border-transparent outline-none transition-all bg-base-bg pr-12" %>
+        <button type="button" data-action="password-visibility#toggle" class="absolute right-4 text-gray-400 focus:outline-none hover:text-primary cursor-pointer">
+          <i class="bi bi-eye-slash text-xl" data-password-visibility-target="icon"></i>
+        </button>
+      </div>
+    </div>
+
+    <%# パスワード確認用（修正箇所2） %>
+    <div class="mb-8" data-controller="password-visibility">
+      <%= f.label :password_confirmation, "パスワード（確認用）", class: "block text-sm font-bold text-base-text mb-2" %>
+      <div class="relative flex items-center">
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", 
+            data: { password_visibility_target: "input" },
+            class: "w-full px-4 py-3 rounded-xl border border-base-border focus:ring-2 focus:ring-accent focus:border-transparent outline-none transition-all bg-base-bg pr-12" %>
+        <button type="button" data-action="password-visibility#toggle" class="absolute right-4 text-gray-400 focus:outline-none hover:text-primary cursor-pointer">
+          <i class="bi bi-eye-slash text-xl" data-password-visibility-target="icon"></i>
+        </button>
+      </div>
+    </div>
+
+    <%# 登録ボタン %>
+    <div class="mb-6">
+      <%= f.submit "登録する", class: "w-full py-4 bg-primary text-white font-bold rounded-xl shadow-lg hover:opacity-90 transition-opacity cursor-pointer" %>
+    </div>
+  <% end %>
+
+  <div class="text-center text-sm">
+    <%= render "devise/shared/links" %>
+  </div>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,47 @@
+<div class="max-w-md mx-auto mt-10 px-6 py-8 bg-white shadow-xl rounded-2xl border border-base-border">
+  <h2 class="text-2xl font-bold text-center text-primary mb-8">ログイン</h2>
+
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <%# メールアドレス %>
+    <div class="mb-5">
+      <%= f.label :email, "メールアドレス", class: "block text-sm font-bold text-base-text mb-2" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", 
+          class: "w-full px-4 py-3 rounded-xl border border-base-border focus:ring-2 focus:ring-accent focus:border-transparent outline-none transition-all" %>
+    </div>
+
+    <%# パスワード %>
+    <div class="mb-5" data-controller="password-visibility">
+      <%= f.label :password, "パスワード", class: "block text-sm font-bold text-base-text mb-2" %>
+      <div class="relative flex items-center">
+        <%= f.password_field :password, autocomplete: "current-password", 
+            data: { password_visibility_target: "input" },
+            class: "w-full px-4 py-3 rounded-xl border border-base-border focus:ring-2 focus:ring-accent focus:border-transparent outline-none transition-all bg-base-bg pr-12" %>
+        
+        <%# 目玉アイコンボタン %>
+        <button type="button" 
+                data-action="password-visibility#toggle" 
+                class="absolute right-4 text-gray-400 focus:outline-none hover:text-primary transition-colors cursor-pointer">
+          <i class="bi bi-eye-slash text-xl" data-password-visibility-target="icon"></i>
+        </button>
+      </div>
+    </div>
+
+    <%# ログイン情報保持 %>
+    <% if devise_mapping.rememberable? %>
+      <div class="flex items-center mb-6">
+        <%= f.check_box :remember_me, class: "w-4 h-4 text-primary border-base-border rounded focus:ring-accent" %>
+        <%= f.label :remember_me, "ログイン情報を保存する", class: "ml-2 block text-sm text-gray-600" %>
+      </div>
+    <% end %>
+
+    <%# ログインボタン %>
+    <div class="mb-6">
+      <%= f.submit "ログイン", class: "w-full py-4 bg-primary text-white font-bold rounded-xl shadow-lg hover:opacity-90 transition-opacity cursor-pointer" %>
+    </div>
+  <% end %>
+
+  <%# 下部のリンク（パスワード忘れなど） %>
+  <div class="text-center text-sm">
+    <%= render "devise/shared/links" %>
+  </div>
+</div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation" data-turbo-temporary>
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,17 @@
+<div class="flex flex-col space-y-3 mt-6 text-sm font-medium text-primary">
+  <%- if controller_name != 'sessions' %>
+    <%= link_to "すでにアカウントをお持ちの方（ログイン）", new_session_path(resource_name), class: "hover:underline" %>
+  <% end %>
+
+  <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+    <%= link_to "新しくアカウントを作る（新規登録）", new_registration_path(resource_name), class: "hover:underline" %>
+  <% end %>
+
+  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+    <%= link_to "パスワードを忘れた方はこちら", new_password_path(resource_name), class: "hover:underline" %>
+  <% end %>
+
+  <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+    <%= link_to "確認メールが届かない場合", new_confirmation_path(resource_name), class: "hover:underline" %>
+  <% end %>
+</div>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <p><%= f.label :email %></p>
+    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,9 @@
       </div>
     </main>
 
-    <%# ボトムナビは独立 %>
-    <%= render 'shared/bottom_navigation' %>
+    <%# 修正ポイント：ログインしている時だけボトムナビを出す %>
+    <% if user_signed_in? %>
+      <%= render 'shared/bottom_navigation' %>
+    <% end %>
   </body>
 </html>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,20 +1,24 @@
-<% flash.each do |type, message| %>
-  <% 
-    # ステータスに関わる色は、ブランドカラーとは別にRails標準のセマンティクスを維持する
-    bg_color = type == "notice" ? "bg-emerald-50 border-emerald-200 text-emerald-800" : "bg-rose-50 border-rose-200 text-rose-800"
-    icon_color = type == "notice" ? "text-emerald-400" : "text-rose-400"
-  %>
-  <div data-controller="flash" 
-      class="fixed top-20 right-4 z-50 max-w-md px-6 py-4 rounded-xl shadow-2xl border transition-all duration-500 <%= bg_color %>">
-    <div class="flex items-center space-x-3">
-      <div class="<%= icon_color %>">
-        <% if type == "notice" %>
-          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path></svg>
-        <% else %>
-          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path></svg>
-        <% end %>
+<div class="fixed top-20 right-4 z-50 flex flex-col gap-3 items-end pointer-events-none">
+  
+  <% flash.each do |type, message| %>
+    <% 
+      bg_color = type == "notice" ? "bg-emerald-50 border-emerald-200 text-emerald-800" : "bg-rose-50 border-rose-200 text-rose-800"
+      icon_color = type == "notice" ? "text-emerald-400" : "text-rose-400"
+    %>
+    
+    <div data-controller="flash" 
+        class="pointer-events-auto max-w-md px-6 py-4 rounded-xl shadow-2xl border transition-all duration-500 <%= bg_color %>">
+      <div class="flex items-center space-x-3">
+        <div class="<%= icon_color %>">
+          <% if type == "notice" %>
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path></svg>
+          <% else %>
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path></svg>
+          <% end %>
+        </div>
+        <span class="text-sm font-bold"><%= message %></span>
       </div>
-      <span class="text-sm font-bold"><%= message %></span>
     </div>
-  </div>
-<% end %>
+  <% end %>
+
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,12 +1,19 @@
 <header class="fixed top-0 inset-x-0 h-16 bg-primary z-50 shadow-sm flex items-center justify-between px-6">
   
+  <%# ロゴ：常に表示 %>
   <%= link_to root_path, class: "flex items-center" do %>
     <%= image_tag 'Pakelog_logo.svg', alt: 'PakeLog Logo', class: 'h-6 w-auto' %>
   <% end %>
 
-  <%# ハンバーガーメニューは text-white で白くする %>
-  <button class="text-white focus:outline-none">
-    <i class="bi bi-list text-4xl"></i>
-  </button>
+  <%# 修正ポイント：ログインしている時だけ右側の要素をまるごと表示 %>
+  <% if user_signed_in? %>
+    <div class="flex items-center space-x-4">
+      <%# 名前とログアウト %>
+      <span class="text-white text-xs font-bold"><%= current_user.name %> さん</span>
+      <%= link_to destroy_user_session_path, data: { turbo_method: :delete }, class: "text-white focus:outline-none" do %>
+        <i class="bi bi-box-arrow-right text-2xl"></i>
+      <% end %>
+    </div>
+  <% end %>
     
 </header>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -269,7 +269,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html, :turbo_stream]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = [ :get, :delete ]
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -16,6 +16,19 @@ module.exports = {
         primary: '#0D233E',
         accent: '#A2D235',
         secondary: '#E5E7EB',
+        base: {
+          border: '#E5E7EB', // 枠線用（標準的なグレー）
+          text: '#4B5563',   // サブテキスト用（少し薄めの黒）
+          bg: '#F9FAFB',     // 薄い背景用
+        },
+        success: {
+          light: '#F0FDF4', // ほんのり緑（背景用）
+          DEFAULT: '#10B981', // メインの緑（文字・アイコン用）
+        },
+        danger: {
+          light: '#FFF1F2', // ほんのり赤（背景用）
+          DEFAULT: '#F43F5E', // メインの赤（文字・アイコン用）
+        },
       },
     },
   },

--- a/db/migrate/20260321042711_remove_password_digest_from_users.rb
+++ b/db/migrate/20260321042711_remove_password_digest_from_users.rb
@@ -1,0 +1,5 @@
+class RemovePasswordDigestFromUsers < ActiveRecord::Migration[7.2]
+  def change
+      remove_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_20_155718) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_21_042711) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,7 +74,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_20_155718) do
   create_table "users", force: :cascade do |t|
     t.string "name", limit: 20, null: false
     t.string "email", null: false
-    t.string "password_digest", null: false
     t.string "avatar_url"
     t.string "provider"
     t.string "uid"

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,9 +1,7 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+one:
+  user: standard_user  # users.ymlで定義した名前に合わせる
+  name: "家電"
 
-# one:
-  # user: one
-  # name: MyString
-
-# two:
-  # user: two
-  # name: MyString
+two:
+  user: standard_user
+  name: "キッチン"

--- a/test/fixtures/item_images.yml
+++ b/test/fixtures/item_images.yml
@@ -1,9 +1,7 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+one:
+  item: one
+  image_url: "https://example.com/image1.jpg"
 
-# one:
-  # item: one
-  # image_url: MyString
-
-# two:
-  # item: two
-  # image_url: MyString
+two:
+  item: two
+  image_url: "https://example.com/image2.jpg"

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -1,13 +1,11 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+one:
+  user: standard_user # users.yml で定義した名前と合わせる
+  category: one
+  name: "お気に入りのドライヤー"
+  memo: "温風が出にくい時はフィルターを掃除すること。"
 
-# one:
-  # user: one
-  # category: one
-  # name: MyString
-  # memo: MyText
-
-# two:
-  # user: two
-  # category: two
-  # name: MyString
-  # memo: MyText
+two:
+  user: standard_user
+  category: two
+  name: "全自動洗濯機"
+  memo: "洗剤投入口は週に一度洗う。"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,10 +1,10 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-# one:
-  # name: MyString
-  # email: one@example.com # 重複しないように変更
-  # password_digest: <%= BCrypt::Password.create('secret') %>
+standard_user:
+  name: "なつのじ"
+  email: "test@example.com"
+  # Deviseの暗号化方式で 'password' という文字列を保存する
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
 
-# two:
-  # name: MyString
-  # email: two@example.com # 重複しないように変更
-  # password_digest: <%= BCrypt::Password.create('secret') %>
+another_user:
+  name: "テストユーザー"
+  email: "another@example.com"
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -1,0 +1,27 @@
+require "application_system_test_case"
+
+class UsersTest < ApplicationSystemTestCase
+  test "新規登録ができること" do
+    visit new_user_registration_path
+
+    fill_in "お名前", with: "なつのじ"
+    fill_in "メールアドレス", with: "new_user@example.com"
+    fill_in "パスワード（6文字以上）", with: "password"
+    fill_in "パスワード（確認用）", with: "password"
+
+    click_on "登録する"
+
+    assert_text "なつのじ さん"
+  end
+
+  test "ログインができること" do
+    visit new_user_session_path
+
+    fill_in "メールアドレス", with: "test@example.com"
+    fill_in "パスワード", with: "password"
+
+    click_on "ログイン"
+
+    assert_text "なつのじ さん"
+  end
+end


### PR DESCRIPTION
### 概要
Deviseによる認証基盤のデザインを一新し、PakeLogのブランドカラー（ネイビー・ライムグリーン）を適用した。また、ユーザー体験向上のため「名前」属性の追加と、パスワード可視化機能を実装した。

### 実行コマンド
1. `bin/rails db:migrate` （nameカラム追加等の反映）
2. `bundle install` （Gemの依存関係確認）
3. `bin/dev` （Tailwind/JSのビルドを伴う起動）

### タスク詳細
- [x] ログイン・新規登録・プロフィール編集画面のTailwind CSSによるスタイリング
- [x] `tailwind.config.js` へのカスタムカラー（primary, accent, base）の定義
- [x] `ApplicationController` での `name` カラムの許可設定
- [x] ログイン状態に応じたヘッダー/ナビゲーション要素の表示制御
- [x] Stimulusによるパスワード表示/非表示切り替えロジックの実装
- [x] プロフィール編集画面でのメールアドレスReadOnly化（編集不可設定）

### テスト・品質管理
- [x] `test/fixtures/` の各データを `devise` 形式および `name` カラム対応に修正
- [x] `test/system/users_test.rb` による新規登録・ログインの正常系テスト実装
- [x] `bin/rails test:system` がエラーなしでパスすることを確認済み
- [x] `bundle exec rubocop` によるコード規約チェックおよび自動修正済み

### 完了定義
- [x] パスワード6文字制限が機能し、日本語でエラーが表示されること
- [x] 新規登録時に `Name` が正常に保存され、ヘッダーに表示されること
- [x] ログイン・ログアウトが正常に機能し、未ログイン時は `/items` 等にアクセスできないこと
- [x] 全てのパスワードフィールドで「目玉アイコン」による可視化切り替えができること