### PR TITLE
画像のメタデータ削除およびリサイズ機能の共通化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "cloudinary"
 
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,10 +128,21 @@ GEM
       multipart-post (~> 2.0)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-aarch64-linux-musl)
+    ffi (1.17.3-arm-linux-gnu)
+    ffi (1.17.3-arm-linux-musl)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86_64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-musl)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -165,6 +176,8 @@ GEM
     matrix (0.4.3)
     mcp (0.8.0)
       json-schema (>= 4.1)
+    mini_magick (5.3.1)
+      logger
     mini_mime (1.1.5)
     minitest (5.27.0)
     msgpack (1.8.0)
@@ -303,6 +316,9 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.3.0)
+      ffi (~> 1.12)
+      logger
     rubyzip (3.2.2)
     securerandom (0.4.1)
     selenium-webdriver (4.41.0)
@@ -380,6 +396,7 @@ DEPENDENCIES
   cloudinary
   debug
   devise
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
   minitest (~> 5.25)
@@ -433,8 +450,17 @@ CHECKSUMS
   faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
+  ffi (1.17.3-aarch64-linux-gnu) sha256=28ad573df26560f0aedd8a90c3371279a0b2bd0b4e834b16a2baa10bd7a97068
+  ffi (1.17.3-aarch64-linux-musl) sha256=020b33b76775b1abacc3b7d86b287cef3251f66d747092deec592c7f5df764b2
+  ffi (1.17.3-arm-linux-gnu) sha256=5bd4cea83b68b5ec0037f99c57d5ce2dd5aa438f35decc5ef68a7d085c785668
+  ffi (1.17.3-arm-linux-musl) sha256=0d7626bb96265f9af78afa33e267d71cfef9d9a8eb8f5525344f8da6c7d76053
+  ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
+  ffi (1.17.3-x86_64-darwin) sha256=1f211811eb5cfaa25998322cdd92ab104bfbd26d1c4c08471599c511f2c00bb5
+  ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
+  ffi (1.17.3-x86_64-linux-musl) sha256=086b221c3a68320b7564066f46fed23449a44f7a1935f1fe5a245bd89d9aea56
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
@@ -449,6 +475,7 @@ CHECKSUMS
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mcp (0.8.0) sha256=ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb
+  mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
@@ -506,6 +533,7 @@ CHECKSUMS
   rubocop-rails (2.34.3) sha256=10d37989024865ecda8199f311f3faca990143fbac967de943f88aca11eb9ad2
   rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  ruby-vips (2.3.0) sha256=e685ec02c13969912debbd98019e50492e12989282da5f37d05f5471442f5374
   rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.41.0) sha256=cdc1173cd55cf186022cea83156cc2d0bec06d337e039b02ad25d94e41bedd22

--- a/app/models/item_image.rb
+++ b/app/models/item_image.rb
@@ -4,4 +4,14 @@ class ItemImage < ApplicationRecord
   has_one_attached :image
 
   validates :image, presence: true
+
+  # 引数 resize_limit でサイズを指定できるように変更。デフォルトは [400, 400]
+  def display_image(resize_limit = [ 400, 400 ])
+    if image.variable?
+      # resize_to_limit を追加することで、指定サイズに収まるようリサイズしつつメタデータを削除
+      image.variant(resize_to_limit: resize_limit, saver: { strip: true }).processed
+    else
+      image
+    end
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -19,7 +19,7 @@
     </div>
   </div>
 
-  <%# 3. リスト部分 %>
+<%# 3. リスト部分 %>
   <div class="px-2 py-5 space-y-4 pb-32">
     <% if @items.empty? %>
       <div class="text-center py-20 bg-white rounded-2xl mx-2">
@@ -31,9 +31,12 @@
           
           <%# 画像表示エリア：Active Storage 対応 %>
           <div class="w-20 h-20 bg-gray-100 rounded-xl mr-4 flex-shrink-0 overflow-hidden">
-            <%# アイテムに関連付けられた最初の画像があるかチェック %>
-            <% if item.item_images.first&.image&.attached? %>
-              <%= image_tag item.item_images.first.image, class: "w-full h-full object-cover" %>
+            <%# 変数に一度代入しておくと、スッキリ書けます %>
+            <% first_image = item.item_images.first %>
+
+            <% if first_image&.image&.attached? %>
+              <%# Modelで定義した display_image を使用 %>
+              <%= image_tag first_image.display_image([200, 200]), class: "w-full h-full object-cover" %>
             <% else %>
               <%# 画像がない場合のプレースホルダー %>
               <div class="w-full h-full flex items-center justify-center text-gray-300">
@@ -58,4 +61,3 @@
       <% end %>
     <% end %>
   </div>
-</div>


### PR DESCRIPTION
### 概要
Active Storage (libvips) を用い、画像表示時に Exif 情報（位置情報等）を削除し、かつ指定サイズへのリサイズを行う共通メソッドを実装。

### 実行コマンド
1. `brew install vips` （画像処理エンジンの導入）
2. `bundle install` （image_processing Gem の反映）
3. `bundle exec rubocop -A` （コード整形）

### タスク詳細
- [x] ItemImage モデルに引数付きの `display_image` メソッドを定義
- [x] `saver: { strip: true }` によるメタデータ削除を実装
- [x] `resize_to_limit` による動的なリサイズ機能の追加
- [x] ライブラリ一覧画面（index）の画像表示を新メソッドへ切り替え（200x200指定）

### 完了定義
- [x] サーバーエラーなく、ライブラリ画面に画像が表示されること
- [x] 保存した画像から GPS 等の情報が削除されていること