### PR TITLE
fix: タイムゾーンを日本標準時(JST)に修正しテスト通過

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,5 +14,10 @@ module PakeLog
 
     # Cloudinaryが提供する加工パラメータをActive Storageがそのまま通すようにする
     config.active_storage.track_variants = true
+
+    # 日本標準時に設定
+    config.time_zone = "Tokyo"
+    # DBの保存時刻もJST（日本時間）に合わせる
+    config.active_record.default_timezone = :local
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,7 +24,7 @@ default: &default
 development:
   <<: *default
   database: pake_log_development
-
+  host: db
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.
   # When left blank, PostgreSQL will use the default role. This is


### PR DESCRIPTION
## 概要
投稿した際の登録時間が、現在時刻より9時間前の表記になってしまっている。
RailsのデフォルトタイムゾーンがUTC（協定世界時）になっていることが原因と思われるため、日本標準時（JST）に修正する。

## 修正内容
- `config/application.rb` のタイムゾーン設定を `Tokyo` に変更。
- ActiveRecordの保存時刻もローカル（JST）に合わせる。

## 完了条件
- 新規登録したパッケージの時間が、現在時刻と一致すること。