### PR TITLE
fix:GIF画像の制限等の実装

### DIFF
--- a/app/javascript/controllers/input_images_controller.js
+++ b/app/javascript/controllers/input_images_controller.js
@@ -41,11 +41,24 @@ export default class extends Controller {
     const newFiles = Array.from(this.inputTarget.files)
     if (newFiles.length === 0) return
 
+    // 🌟 GIFをフロントエンドでフィルタリング
+    const validFiles = newFiles.filter(file => {
+      if (file.type === "image/gif") {
+        alert("GIF形式の画像はアップロードできません。")
+        return false
+      }
+      return true
+    })
+
+    // 🌟 フィルタリング後のファイルがゼロなら終了
+    if (validFiles.length === 0) return
+
     const totalCount = this.allImages.length + this.newFiles.length
     const availableSlots = 3 - totalCount
     if (availableSlots <= 0) return
 
-    const filesToAdd = newFiles.slice(0, availableSlots)
+    // 🌟 修正箇所：newFiles ではなく validFiles を slice する
+    const filesToAdd = validFiles.slice(0, availableSlots)
     this.newFiles = [...this.newFiles, ...filesToAdd]
     
     this.renderAll()

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,6 +12,7 @@ class Item < ApplicationRecord
 
   # 🌟 画像のバリデーション（新規・編集共通）
   validate :images_presence_and_count
+  validate :validate_images_format
 
   def cover_image
     images.first
@@ -39,6 +40,17 @@ class Item < ApplicationRecord
       end
     else
       errors.add(:images, "を1枚以上選択してください。")
+    end
+  end
+
+  def validate_images_format
+    return unless images.attached?
+
+    images.each do |image|
+      # image/gif が含まれていたらエラーを追加する
+      if image.content_type == "image/gif"
+        errors.add(:images, "にGIF形式は使用できません。JPEGまたはPNG形式を選択してください")
+      end
     end
   end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -25,10 +25,11 @@
       </div>
 
       <div class="hidden">
+        <%# accept属性でGIFを除外し、iOS Chrome向けにカンマ後のスペースを詰める %>
         <%= f.file_field :images, 
             multiple: true, 
             data: { input_images_target: "input", action: "change->input-images#preview" }, 
-            accept: "image/*",
+            accept: "image/png,image/jpeg",
             id: "item_image_input" %>
       </div>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,4 +1,4 @@
-<div class="px-6 py-8 pb-32"> <%# 🌟 pb-32 を追加（ボトムナビ対策） %>
+<div class="px-6 py-8 pb-32">
   <%# 🌟 アクション名を syncInput から syncToInput に修正 %>
   <%= form_with(model: @item, data: { turbo: true, action: "submit->input-images#syncToInput" }, multipart: true) do |f| %>
 
@@ -26,10 +26,11 @@
       </div>
 
       <div class="hidden">
+        <%# accept属性でGIFを除外し、iOS Chrome向けにカンマ後のスペースを詰める %>
         <%= f.file_field :images, 
             multiple: true, 
             data: { input_images_target: "input", action: "change->input-images#preview" }, 
-            accept: "image/*",
+            accept: "image/png,image/jpeg",
             id: "item_image_input" %>
       </div>
 


### PR DESCRIPTION
## 概要
画像登録において、仕様外の挙動および特定の環境での不具合を解消する。

## 対応内容
1. **GIF画像の制限**
   - ActiveStorageのバリデーションを追加し、GIFファイルの登録を不可にする。
   - `image/jpeg`, `image/jpg`, `image/png` のみに制限。
2. **iOS Chromeでのカメラ起動調査**
   - iOS 26.2.1（Chrome）環境で直接写真が撮れない問題を調査。
   - `input` タグの `accept` 属性や `capture` 属性の見直し。

## 完了条件
- GIF画像をアップロードしようとした際にエラーが表示されること。
- iOS Chrome環境でのカメラ起動の可否が確認でき、必要であれば修正されていること。