### PR TITLE
feat: Ransackカテゴリフィルタの堅牢化とGIFバリデーションの実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,7 +7,10 @@ class ItemsController < ApplicationController
     @items = @q.result(distinct: true)
                 .includes(:category, images_attachments: :blob)
                 .order(updated_at: :desc)
-  end
+
+    # ビューで使用するカテゴリ一覧を、ログインユーザーのものに限定して取得
+    @categories = current_user.categories.distinct
+    end
 
   def show
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -13,8 +13,10 @@
           全て
         <% end %>
 
-        <% current_user.categories.each do |category| %>
+        <% @categories.each do |category| %>
+          <%# 判定をより堅牢にするため .to_s を使用 %>
           <% is_active = params.dig(:q, :category_id_eq).to_s == category.id.to_s %>
+          
           <%= link_to items_path(q: { category_id_eq: category.id }), 
               class: "#{is_active ? 'bg-accent border-accent' : 'bg-gray-100 border-transparent'} text-primary px-6 py-2 rounded-full text-sm font-bold whitespace-nowrap border transition-all shadow-sm active:scale-95" do %>
             <%= category.name %>


### PR DESCRIPTION
### 概要
商品名だけでなく「メモ」の内容からもキーワードで部分一致検索ができるようにし、目的の説明書をすぐに見つけられるようにする。

### タスク詳細
- [x] `ransack` Gemを導入し、`bundle install` を実行
- [x] `ItemsController#index` を修正し、Ransackの検索クエリを受け取れるように実装
- [x] 検索結果が0件だった場合に「該当するアイテムはありません」と表示する条件分岐を追加
- [x] カテゴリによる絞り込み機能の統合

- **フィルタ機能の追加：**
    - カテゴリによる絞り込み。

### 完了定義
- フィルタが正しく動作すること。