### PR TITLE
feat: 商品名とメモによるキーワード検索機能の実装（UI調整済み）

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,7 +24,7 @@ class Item < ApplicationRecord
 
   # Ransack用設定
   def self.ransackable_attributes(auth_object = nil)
-    [ "name", "category_id", "created_at" ]
+    [ "name", "category_id", "memo", "created_at" ]
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -3,6 +3,26 @@
   <%# --- 1. ヘッダー & カテゴリタブエリア --- %>
   <%= render 'shared/header' %>
 
+  <div class="px-3 pt-4 mb-2">
+    <%= search_form_for @q, url: items_path, method: :get do |f| %>
+      <div class="relative group">
+        <%# 虫眼鏡アイコン %>
+        <div class="absolute inset-y-0 left-4 flex items-center pointer-events-none">
+          <i class="bi bi-search text-gray-400 group-focus-within:text-accent transition-colors"></i>
+        </div>
+
+        <%# 検索入力欄：名前(name)とメモ(memo)を同時検索 %>
+        <%= f.search_field :name_or_memo_cont, 
+            placeholder: "パケの名前 や メモで検索 ...", 
+            class: "w-full pl-14 pr-4 py-4 rounded-2xl bg-white border-none text-primary text-sm font-bold shadow-sm focus:ring-2 focus:ring-accent transition-all placeholder:text-gray-300" %>
+        
+        <%# 重要：カテゴリで絞り込んでいる最中なら、そのカテゴリIDを隠しパラメータで保持する %>
+        <% if params.dig(:q, :category_id_eq).present? %>
+          <%= f.hidden_field :category_id_eq, value: params.dig(:q, :category_id_eq) %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
   <%# アイテムが存在するとき、または検索・フィルタリング中の時だけタブを表示 %>
   <% if @items.any? || params[:q].present? %>
     <div class="bg-white/95 backdrop-blur-md border-b border-base-border/50 sticky top-16 z-30 pb-3 pt-2">


### PR DESCRIPTION
### 概要
商品名だけでなく「メモ」の内容からもキーワードで部分一致検索ができるようにし、目的の説明書をすぐに見つけられるようにする。

### タスク詳細
- [x] 一覧画面（`index.html.erb`）に、商品名 (`name`) とメモ (`memo`) を対象にした検索窓（テキストフィールド）を設置

- **フィルタ機能の追加：**
    - カテゴリ（既存＋カスタム）による絞り込み。
    - お気に入り済みアイテムのみの抽出。

### 完了定義
- 検索窓に文字を入力して実行した際、商品名またはメモにその文字が含まれるアイテムだけがフィルタリングされて表示されること。
- カテゴリ選択とキーワード検索が組み合わせて利用できること。